### PR TITLE
feat(whereiam_bunkers/client.lua): Remove 'break' statement

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -84,7 +84,6 @@ CreateThread(function()
                 end
             end
         end
-        break
     end
 end)
 


### PR DESCRIPTION
Allow more than 1 bunker to be read.